### PR TITLE
chore: Add the repository field to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "farmbot"
 description = "Farm manager manager bot"
 homepage = "https://github.com/jasha10/farmbot"
+repository = "https://github.com/jasha10/farmbot"
 edition.workspace = true
 license.workspace = true
 version= "0.1.19"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "farmbot"
 description = "Farm manager manager bot"
 homepage = "https://github.com/jasha10/farmbot"
-repository = "https://github.com/jasha10/farmbot"
+repository.workspace = true
 edition.workspace = true
 license.workspace = true
 version= "0.1.19"
@@ -16,3 +16,4 @@ members = ["crates/*"]
 version = "0.1.19"
 edition = "2021"
 license = "MIT"
+repository = "https://github.com/jasha10/farmbot"

--- a/crates/stowsave/Cargo.toml
+++ b/crates/stowsave/Cargo.toml
@@ -5,6 +5,7 @@ homepage = "https://github.com/Jasha10/farmbot/tree/main/crates/stowsave"
 edition.workspace = true
 license.workspace = true
 version.workspace = true
+repository.workspace = true
 
 [dependencies]
 anyhow = "1"

--- a/crates/stowsave/Cargo.toml
+++ b/crates/stowsave/Cargo.toml
@@ -2,10 +2,10 @@
 name = "stowsave"
 description = "Automates moving files into a stow directory then using stow to create symlinks back to where the files came from"
 homepage = "https://github.com/Jasha10/farmbot/tree/main/crates/stowsave"
-repository = "https://github.com/Jasha10/farmbot/"
 edition.workspace = true
 license.workspace = true
 version.workspace = true
+repository.workspace = true
 
 [dependencies]
 anyhow = "1"

--- a/crates/stowsave/Cargo.toml
+++ b/crates/stowsave/Cargo.toml
@@ -2,10 +2,10 @@
 name = "stowsave"
 description = "Automates moving files into a stow directory then using stow to create symlinks back to where the files came from"
 homepage = "https://github.com/Jasha10/farmbot/tree/main/crates/stowsave"
+repository = "https://github.com/Jasha10/farmbot/"
 edition.workspace = true
 license.workspace = true
 version.workspace = true
-repository.workspace = true
 
 [dependencies]
 anyhow = "1"


### PR DESCRIPTION
To allow [Crates.io](https://crates.io/) , [lib.rs](https://lib.rs/) and the [Rust Digger](https://rust-digger.code-maven.com/) to link to it. See [the manifest](https://doc.rust-lang.org/cargo/reference/manifest.html#the-repository-field) for the explanation.